### PR TITLE
replaced reference to odds with static odds at given time

### DIFF
--- a/website/lines/arbitrage.py
+++ b/website/lines/arbitrage.py
@@ -43,18 +43,20 @@ def find_arbitrage(game_book_map):
                 #Check if this arbitrage has already been added; Fixes problem with same arbitrage opportunity being readded
                 #In combination with not rescanning entire Odds table, this will speed up arbitrage finding and eliminate duplicate arbitrage opportunities
                 try:
-                    already_found_arbitrage = (db.session.query(ArbitrageOpportunity).filter_by(game_id=game_id, home_team_odds_id=odds1.id, away_team_odds_id=odds2.id, profit_percentage=arbitrage_value-1).one())
+                    already_found_arbitrage = (db.session.query(ArbitrageOpportunity).filter_by(game_id=odds1.game_id, home_odds_bookmaker_id=odds1.bookmaker_id, home_odds=odds1.home_team_odds, away_odds_bookmaker_id=odds2.bookmaker_id, away_odds=odds2.away_team_odds, profit_percentage=arbitrage_value-1).one())
+                    print(already_found_arbitrage)
                 except NoResultFound:
-                    arbitrage_opp = ArbitrageOpportunity(game_id=odds1.game_id, home_team_odds_id=odds1.id, away_team_odds_id=odds2.id, profit_percentage=arbitrage_value-1)
+                    arbitrage_opp = ArbitrageOpportunity(game_id=odds1.game_id, home_odds_bookmaker_id=odds1.bookmaker_id, home_odds=odds1.home_team_odds, away_odds_bookmaker_id=odds2.bookmaker_id, away_odds=odds2.away_team_odds, profit_percentage=arbitrage_value-1)
                     arbitrage_opps.append(arbitrage_opp)
 
             #book 1 away, book 2 home
             arbitrage_value = calculate_arbitrage(odds2.home_team_odds, odds1.away_team_odds)
             if arbitrage_value < 1:
                 try:
-                    already_found_arbitrage = (db.session.query(ArbitrageOpportunity).filter_by(game_id=game_id, home_team_odds_id=odds2.id, away_team_odds_id=odds1.id, profit_percentage=1-arbitrage_value).one())
+                    already_found_arbitrage = (db.session.query(ArbitrageOpportunity).filter_by(game_id=odds1.game_id, home_odds_bookmaker_id=odds2.bookmaker_id, home_odds=odds2.home_team_odds, away_odds_bookmaker_id=odds1.bookmaker_id, away_odds=odds1.away_team_odds, profit_percentage=1-arbitrage_value).one())
+                    print(already_found_arbitrage)
                 except NoResultFound:
-                    arbitrage_opp = ArbitrageOpportunity(game_id=odds1.game_id, home_team_odds_id=odds2.id, away_team_odds_id=odds1.id, profit_percentage=1-arbitrage_value)
+                    arbitrage_opp = ArbitrageOpportunity(game_id=odds1.game_id, home_odds_bookmaker_id=odds2.bookmaker_id, home_odds=odds2.home_team_odds, away_odds_bookmaker_id=odds1.bookmaker_id, away_odds=odds1.away_team_odds, profit_percentage=1-arbitrage_value)
                     arbitrage_opps.append(arbitrage_opp)
                 
     print("Finished finding arbitrage opportunities")

--- a/website/lines/lines.py
+++ b/website/lines/lines.py
@@ -313,19 +313,19 @@ def arbitrage_opportunities():
     
     page = request.args.get('page', 1, type=int)
     per_page = 10
-    AwayOdds = aliased(Odds)
+    AwayBookmakers = aliased(Bookmakers)
 
     query = db.session.query(
         ArbitrageOpportunity,
         Games,
-        Odds,
-        AwayOdds
+        Bookmakers,
+        AwayBookmakers
     ).join(
         Games, ArbitrageOpportunity.game_id == Games.id
     ).join(
-        Odds, ArbitrageOpportunity.home_team_odds_id == Odds.id
+        Bookmakers, ArbitrageOpportunity.home_odds_bookmaker_id == Bookmakers.id
     ).join(
-        AwayOdds, ArbitrageOpportunity.away_team_odds_id == AwayOdds.id
+        AwayBookmakers, ArbitrageOpportunity.away_odds_bookmaker_id == AwayBookmakers.id
     )
 
     date_query = request.args.get('date')
@@ -348,12 +348,12 @@ def arbitrage_opportunities():
 
     for arbitrage in arbitrages:
         arbitrage[0].profit_percentage_display = str(round(abs(arbitrage[0].profit_percentage) * 100, 2))+"%"
-        arbitrage[2].home_team_odds_display = arbitrage[2].home_team_odds
-        arbitrage[3].away_team_odds_display = arbitrage[3].away_team_odds
-        if arbitrage[2].home_team_odds > 0:
-            arbitrage[2].home_team_odds_display = "+"+str(arbitrage[2].home_team_odds)
-        if arbitrage[3].away_team_odds > 0:
-            arbitrage[3].away_team_odds_display = "+"+str(arbitrage[3].away_team_odds)
+        arbitrage[0].home_team_odds_display = arbitrage[0].home_odds
+        arbitrage[0].away_team_odds_display = arbitrage[0].away_odds
+        if arbitrage[0].home_odds > 0:
+            arbitrage[0].home_team_odds_display = "+"+str(arbitrage[0].home_odds)
+        if arbitrage[0].away_odds > 0:
+            arbitrage[0].away_team_odds_display = "+"+str(arbitrage[0].away_odds)
         
         eastern = pytz.timezone('US/Eastern')
         arbitrage_time_eastern = arbitrage[0].time_found.astimezone(eastern)

--- a/website/lines/static/arbitrage.css
+++ b/website/lines/static/arbitrage.css
@@ -76,6 +76,11 @@ tr:nth-child(odd) {
     margin-bottom: 10px;
 }
 
+label {
+    margin-bottom: 5px; /* Adds space between label and input */
+    color: rgb(165, 155, 155);
+}
+
 input {
     border: 2px solid black;
 }

--- a/website/lines/templates/arbitrage.html
+++ b/website/lines/templates/arbitrage.html
@@ -66,11 +66,11 @@
                 {% for arb in arbitrages %}
                 <tr>
                     <td>{{ arb[1].home_team }}</td>
-                    <td>{{ arb[2].bookmaker.title }}</td>
-                    <td>{{ arb[2].home_team_odds_display }}</td>
+                    <td>{{ arb[2].title }}</td>
+                    <td>{{ arb[0].home_team_odds_display }}</td>
                     <td>{{ arb[1].away_team }}</td>
-                    <td>{{ arb[3].bookmaker.title }}</td>
-                    <td>{{ arb[3].away_team_odds_display }}</td>
+                    <td>{{ arb[3].title }}</td>
+                    <td>{{ arb[0].away_team_odds_display }}</td>
                     <td>{{ arb[0].profit_percentage_display}}</td>
                     <td>{{ arb[0].time_found_display }}</td>
                 </tr>

--- a/website/models.py
+++ b/website/models.py
@@ -62,15 +62,13 @@ class Bookmakers(db.Model):
 
 class ArbitrageOpportunity(db.Model):
     id = db.Column(db.Integer, primary_key=True, nullable=False)
-
     game_id = db.Column(db.String, db.ForeignKey('games.id'), nullable=False)
     game = db.relationship('Games', backref='arbitrage_opportunities')
-
-    home_team_odds_id = db.Column(db.Integer, db.ForeignKey('odds.id'), nullable=False)
-    away_team_odds_id = db.Column(db.Integer, db.ForeignKey('odds.id'), nullable=False)
-    home_odds = db.relationship('Odds', foreign_keys=[home_team_odds_id], backref='arbitrage_home_opportunities')
-    away_odds = db.relationship('Odds', foreign_keys=[away_team_odds_id], backref='arbitrage_away_opportunities')
-
+    home_odds_bookmaker_id = db.Column(db.Integer, db.ForeignKey('bookmakers.id'), nullable=False)
+    away_odds_bookmaker_id = db.Column(db.Integer, db.ForeignKey('bookmakers.id'), nullable=False)
+    home_odds = db.Column(db.Integer, nullable=False)
+    away_odds = db.Column(db.Integer, nullable=False)
     profit_percentage = db.Column(db.Float, nullable=False)
     time_found = db.Column(db.DateTime(timezone=True), default=func.now())
+
 


### PR DESCRIPTION
I discovered a new bug with the arbitrage opportunity finding/maintaining. Because our odds objects can be updated whenever we make an API call to the odds API, our arbitrage opportunity tuples can become inaccurate if they end up being stale. However, we want to display historical arbitrage and current arbitrage (in order to show that our product works). As a result, the foreign key references to odds tuples has been replaced by bookmaker ids (which are static and will never change), and static attributes for the home odds and away odds have been added. This way, the arbitrage table will represent a list of arbitrages at a given timestamp. They may no longer necessarily be active, but we will know what the odds were at that given time when the arbitrage was found. This required some changing to the database and how we query the arbitrage table, which has been modified. It has been tested and should be working.